### PR TITLE
simple fix, indexing non-ordinal, non-nested factors with index f

### DIFF
--- a/toolbox/anova/parglm.m
+++ b/toolbox/anova/parglm.m
@@ -301,6 +301,7 @@ for f = 1 : nFactors
             end
             n = n + length(uF) - 1;
             parglmo.factors{f}.order = 1;
+            parglmo.factors{f}.factors = f; %MDSA - missing factor for non-nested, non-ordinal factors            
         else % if nested
             ind = find(nested(:,2)==f);
             ref = nested(ind,1);


### PR DESCRIPTION
For non-ordinal, non-nested factors the parglmo.factors{ii}.factors is empty. Here I used the index "f" to populate the missing fields.